### PR TITLE
Adding presenters

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The workshop is being held at the [US EPA campus in Research Triangle Park, NC] 
 |-------|-----|------------------------------|---------------------------|
 |8:00 AM - 8:15 AM||Welcome Day 2 and Welcome to DDES Folks||   
 |**Workshop**||||
-|8:15 AM - 11:50 AM|C111 A,B,C|Version Control, GitHub, and Bitbucket Workshop|Many Presenters|
+|8:15 AM - 11:50 AM|C111 A,B,C|Version Control, GitHub, and Bitbucket Workshop|Jameel Alsalam, Terry Brown, Sharon Kenny|
 |11:50 AM - Noon||Wrap-up|Ann Vega|
 
 *Note:  This agenda is lovingly made with RStudio, R, `rmarkdown`, and `knitr`.  If interested, as Jeff for details, or look at the [source](index.Rmd)*


### PR DESCRIPTION
 Adding presenters of the workshop titled "Version Control, GitHub, and Bitbucket Workshop"

@jhollist  - Jeff, hello!  I am asking management for travel funds to attend the 2018 R /DDES Workshop at RTP and I would like to provide the agenda for the meeting as a support document.  Therefore, I would like to ask if you can please update the agenda with the names of those supporting the git workshop.